### PR TITLE
Added NPM scripts; also new dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ Docker-Image with ready-to-use Gulp-Tasks.
 
 ## Dockerhub
 https://hub.docker.com/r/ipunktbs/gulp-tasks/
+
+## Tasks

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -1,4 +1,13 @@
+var gulp = require('gulp');
 var requireDir = require('require-dir');
+var gulpSequence = require('gulp-sequence');
 
 requireDir('./tasks', {recurse: true});
 require('./project/gulpfile.js');
+
+var buildDev = function(cb) {
+    global.development = true;
+    gulpSequence('build', cb);
+};
+
+gulp.task('build:dev', buildDev);

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -6,21 +6,22 @@
   "dependencies": {},
   "devDependencies": {
     "require-dir": "^0.3.0",
-    "path": "^0.12.0",
 
     "gulp": "^3.9.0",
     "gulp-watch": "^4.3.0",
-    "gulp-concat": "^2.6.0",
-    "gulp-jshint": "^2.0.0",
-    "gulp-rename": "^1.2.0",
     "gulp-sass": "^2.3.0",
-    "gulp-shell": "^0.5.0",
-    "gulp-uglify": "^1.5.0",
+    "gulp-sequence": "^0.4.5",
+    "gulp-if": "^2.0.0",
+    "browser-sync": "^2.12.5",
+    "gulp-sourcemaps": "^2.0.0",
+    "gulp-autoprefixer": "^3.1.0",
+    "gulp-cssnano": "^2.1.2"
 
-    "browserify": "^13.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "gulp build",
+    "build:dev": "gulp build:dev",
+    "watch": "gulp watch"
   },
   "author": "ipunkt Business Solutions / info@ipunkt.biz",
   "license": "MIT"


### PR DESCRIPTION
Added NPM scripts as shortcuts to gulp build, build:dev and watch.
build:dev sets global variable "development" to true, which will be needed for the task modules to follow different behaviours.

Also added new dependencies needed for tasks.
