### PR TITLE
workaround for always running watch tasks in development-mode

### DIFF
--- a/gulp/tasks/css.js
+++ b/gulp/tasks/css.js
@@ -28,5 +28,6 @@ gulp.task('css', function() {
 });
 
 gulp.task('css:watch', function(){
+    global.development = true;
     gulp.watch(paths.src, ['css']);
 });


### PR DESCRIPTION
we need to set the development global for every watch task to true.
