### PR TITLE
only gzip when set in config

### DIFF
--- a/example/gulp_config.json
+++ b/example/gulp_config.json
@@ -8,6 +8,7 @@
     "css": {
       "src": "scss",
       "dest": "css",
+      "gzip": true,
       "autoprefixer": {
         "browsers": ["last 3 version"]
       },

--- a/gulp/tasks/css.js
+++ b/gulp/tasks/css.js
@@ -25,8 +25,8 @@ gulp.task('css', function() {
         .pipe(gulpif(!global.development, cssnano({autoprefixer: false})))
         .pipe(gulpif(global.development, sourcemaps.write()))
         .pipe(gulp.dest(paths.dest)) //output files
-        .pipe(gulpif(!global.development, gzip())) //gzip AFTER output; this should keep the original files
-        .pipe(gulpif(!global.development, gulp.dest(paths.dest))) //output gzipped files
+        .pipe(gulpif(!global.development && config.tasks.css.gzip, gzip())) //gzip AFTER output; this should keep the original files
+        .pipe(gulpif(!global.development && config.tasks.css.gzip, gulp.dest(paths.dest))) //output gzipped files
         .pipe(gulpif(global.development, browserSync.stream()))
 });
 


### PR DESCRIPTION
gulp_config.js must contain a `"gzip": true` for the task you want to compress (currently only css)
