### PR TITLE
Remove browser-sync; Update gulp_config.json and readme.md examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,57 @@ Build by yourself:
 
 ## Tasks
 
+### clean
+Deletes the dest/public directory as defined in your `gulp_config.json`.
+
+### copy
+Copies files from one directory to another.
+Can be configured to copy as many individual files or directories as you want.
+```json
+"copy": [
+  {
+    "src": "YOUR_PATH/**/*", //supports glob syntax
+    "base": "YOUR_BASE", //part of your path that will be your base; copy will start from here
+    "dest": "YOUR_DEST_PATH"
+  }
+]
+```
+
 ### css
 Compiles sass and/or scss to css files using gulp-sass.
-Also contains an autoprefixer, cssnano (minify), sourcemaps and browserSync
-Sourcemaps will only be generated when running build:dev.
-Same for browserSync.
+Also contains an autoprefixer, cssnano (minify), sourcemaps and gzip.
+Sourcemaps will only be generated when running `gulp build:dev`.
+
+```json
+"css": {
+  "src": "YOUR_SRC_DIR",
+  "dest": "YOUR_DEST_DIR",
+  "gzip": true, //false if you do not want to additionally gzip your resulting css files.
+  "autoprefixer": {
+    "browsers": ["last 3 version"]
+  },
+  "sass": { //see https://github.com/sass/node-sass#options
+    "indentedSyntax": false,
+    "includePaths": []
+  },
+  "extensions": ["sass", "scss", "css"] //sourcefile extensions you want to compile.
+}
+```
+
+### browserify
+Browserify / Watchify task; can be configured to use transforms (currently only ractify).
+Also contains uglify, sourcemap and gzip.
+Sourcemaps will only be generated when running `gulp build:dev`.
+
+```json
+"browserify": {
+  "src": "YOUR/ENTRY/PATH/FILE.JS",
+  "dest": "YOU/DEST/PATH/FILE.JS",
+  "gzip": true, //false if you do not want to additionally gzip your resulting css files.
+  "transforms": { //add your transforms here
+    "ractify": {
+      "extension": "html" //file extension for ractive components
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Deletes the dest/public directory as defined in your `gulp_config.json`.
 ### copy
 Copies files from one directory to another.
 Can be configured to copy as many individual files or directories as you want.
-```json
+```js
 "copy": [
   {
     "src": "YOUR_PATH/**/*", //supports glob syntax
@@ -30,7 +30,7 @@ Compiles sass and/or scss to css files using gulp-sass.
 Also contains an autoprefixer, cssnano (minify), sourcemaps and gzip.
 Sourcemaps will only be generated when running `gulp build:dev`.
 
-```json
+```js
 "css": {
   "src": "YOUR_SRC_DIR",
   "dest": "YOUR_DEST_DIR",
@@ -51,7 +51,7 @@ Browserify / Watchify task; can be configured to use transforms (currently only 
 Also contains uglify, sourcemap and gzip.
 Sourcemaps will only be generated when running `gulp build:dev`.
 
-```json
+```js
 "browserify": {
   "src": "YOUR/ENTRY/PATH/FILE.JS",
   "dest": "YOU/DEST/PATH/FILE.JS",

--- a/example/gulp_config.json
+++ b/example/gulp_config.json
@@ -30,7 +30,7 @@
     },
     "copy": [
       {
-        "src": "static/*",
+        "src": "static/**/*",
         "base": "static",
         "dest": "."
       }

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -15,7 +15,6 @@
     "gulp-sass": "^2.3.0",
     "gulp-sequence": "^0.4.5",
     "gulp-if": "^2.0.0",
-    "browser-sync": "^2.12.5",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-cssnano": "^2.1.2",

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -8,7 +8,6 @@ var gulpif = require('gulp-if');
 var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var uglify = require('gulp-uglify');
-var browserSync = require('browser-sync');
 var sourcemaps = require('gulp-sourcemaps');
 var gzip = require('gulp-gzip');
 var browserify = require('browserify');
@@ -54,8 +53,7 @@ function browserifyTask(watch) {
             .pipe(gulpif(global.development, sourcemaps.write()))
             .pipe(gulp.dest(paths.dest))
             .pipe(gulpif(!global.development && config.tasks.browserify.gzip, gzip())) //gzip AFTER output; this should keep the original files
-            .pipe(gulpif(!global.development && config.tasks.browserify.gzip, gulp.dest(paths.dest))) //output gzipped files
-            .pipe(gulpif(global.development, browserSync.stream()));
+            .pipe(gulpif(!global.development && config.tasks.browserify.gzip, gulp.dest(paths.dest))); //output gzipped files
     }
 
     //only relevant for watchify

--- a/gulp/tasks/css.js
+++ b/gulp/tasks/css.js
@@ -4,7 +4,6 @@ if(!config.tasks.css) return;
 
 var gulp = require('gulp');
 var gulpif = require('gulp-if');
-var browserSync = require('browser-sync');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var autoprefixer = require('gulp-autoprefixer');
@@ -26,8 +25,7 @@ gulp.task('css', function() {
         .pipe(gulpif(global.development, sourcemaps.write()))
         .pipe(gulp.dest(paths.dest)) //output files
         .pipe(gulpif(!global.development && config.tasks.css.gzip, gzip())) //gzip AFTER output; this should keep the original files
-        .pipe(gulpif(!global.development && config.tasks.css.gzip, gulp.dest(paths.dest))) //output gzipped files
-        .pipe(gulpif(global.development, browserSync.stream()))
+        .pipe(gulpif(!global.development && config.tasks.css.gzip, gulp.dest(paths.dest))); //output gzipped files
 });
 
 gulp.task('css:watch', function(){


### PR DESCRIPTION
- Browser-sync removed for now since we do not know how to use it or if we want to use it.
- Also added some better examples in gulp_config.json (using glob-syntax, etc.).
- readme.md now includes all tasks and contains commented examples from the config file.
