### PR TITLE
reimplements browserify:watch task (should work as intended)

### DIFF
--- a/gulp/package.json
+++ b/gulp/package.json
@@ -26,7 +26,8 @@
     "watchify": "^3.7.0",
     "ractive": "^0.7.3",
     "ractify": "^0.6.0",
-    "merge-stream": "^1.0.0"
+    "merge-stream": "^1.0.0",
+    "chalk": "^1.1.3"
   },
   "scripts": {
     "build": "gulp build",

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -4,6 +4,7 @@ if(!config.browserify) return;
 
 var gulp = require('gulp');
 var gutil = require('gulp-util');
+var chalk = require('chalk');
 var gulpif = require('gulp-if');
 var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
@@ -58,10 +59,16 @@ function browserifyTask(watch) {
 
     //only relevant for watchify
     b.on('update', function() {
+        gutil.log('Starting', '\'' + chalk.cyan('browserify') + '\'...');
+
         var startTime = Date.now();
         bundle();
         var diffTime = Date.now() - startTime;
-        console.log("Finished 'browserify' after "+diffTime+" ms");
+
+        gutil.log(
+            'Finished', '\'' + chalk.cyan('browserify') + '\'',
+            'after', chalk.magenta(diffTime), 'ms'
+        );
     });
     return bundle();
 }
@@ -70,10 +77,7 @@ gulp.task('browserify', function() {
     return browserifyTask(false);
 });
 
-/*
- FIXME does not work yet
 gulp.task('browserify:watch', function(){
     global.development = true;
     return browserifyTask(true);
 });
-*/


### PR DESCRIPTION
also adds logging more similar to the original gulp logging for watchify
