### PR TITLE
extend sass task with gulp-rev

### DIFF
--- a/example/gulp_config.js
+++ b/example/gulp_config.js
@@ -2,6 +2,8 @@ module.exports = {
   sass: {
     src: "src/scss/**/*.{sass,scss,css}",
     dest: "public/css",
+    manifest: "config",
+    revision: false,
     gzip: true,
     autoprefixer: {
       browsers: ["last 3 version"]

--- a/gulp/package.json
+++ b/gulp/package.json
@@ -37,7 +37,9 @@
     "browserify": "^13.0.0",
     "ractify": "^0.6.0",
     "watchify": "^3.7.0",
-    "gulp-uglify": "^1.5.3"
+    "gulp-uglify": "^1.5.3",
+
+    "gulp-rev": "^7.1.2"
   },
   "scripts": {
     "build": "gulp build",

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -2,6 +2,7 @@
 
 if(!config.sass) return;
 
+var fs = require('fs');
 var gulp = require('gulp');
 var gulpif = require('gulp-if');
 var sass = require('gulp-sass');
@@ -10,15 +11,23 @@ var autoprefixer = require('gulp-autoprefixer');
 var cssnano = require('gulp-cssnano');
 var gzip = require('gulp-gzip');
 var path = require('path');
+var rev = require('gulp-rev');
+var fs = require('fs');
+
 const sassError  = require('gulp-sass-error').gulpSassError;
 const throwError = true;
 
 var paths = {
     src: path.join(projectPath, config.sass.src),
-    dest: path.join(projectPath, config.sass.dest)
+    dest: path.join(projectPath, config.sass.dest),
+    manifest: path.join(projectPath, config.sass.manifest)
 };
 
 gulp.task('sass', function() {
+
+    //overwrite rev-manifest as empty json-object
+    fs.writeFileSync(path.join(paths.manifest, 'rev-manifest.json'), '{}');
+
     return gulp.src(paths.src)
         //sourcemaps init
         .pipe(gulpif(global.development, sourcemaps.init()))
@@ -31,8 +40,14 @@ gulp.task('sass', function() {
         .pipe(gulpif(!global.development, cssnano({autoprefixer: false})))
         .pipe(gulpif(global.development, sourcemaps.write()))
         .pipe(gulp.dest(paths.dest)) //output files
+
         .pipe(gulpif(!global.development && config.sass.gzip, gzip())) //gzip AFTER output; this should keep the original files
-        .pipe(gulpif(!global.development && config.sass.gzip, gulp.dest(paths.dest))); //output gzipped files
+        .pipe(gulpif(!global.development && config.sass.gzip, gulp.dest(paths.dest))) //output gzipped files
+
+        .pipe(gulpif(config.sass.revision, rev()))
+        .pipe(gulpif(config.sass.revision, gulp.dest(paths.dest))) //write rev'd file
+        .pipe(gulpif(config.sass.revision, rev.manifest()))
+        .pipe(gulpif(config.sass.revision, gulp.dest(paths.manifest))); //write rev-manifest
 });
 
 gulp.task('sass:watch', function(){


### PR DESCRIPTION
extend the sass task with gulp-rev which is used for asset revisioning (via appending a hash to filename)
