### PR TITLE
downgrade webpack auf 2.2.1 wegen relative/absolute path breaking changes

### DIFF
--- a/gulp/package.json
+++ b/gulp/package.json
@@ -28,7 +28,7 @@
     "gulp-concat": "^2.6.0",
     "ractive": "^0.8.0",
     "rcu": "^0.9.0",
-    "webpack": "^2.2.0-rc",
+    "webpack": "2.2.1",
     "json-loader": "^0.5.4",
     "ractivejs-loader": "git://github.com/ipunkt/ractivejs-loader",
     "merge-stream": "^1.0.0",


### PR DESCRIPTION
downgrade webpack auf 2.2.1 wegen relative/absolute path breaking changes