### PR TITLE
keep unused and dead_code in uglifyjs 

### DIFF
--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -57,7 +57,9 @@ function setupConfig(conf) {
             }),
             new webpack.optimize.UglifyJsPlugin({
                 compress: {
-                    warnings: false
+                    warnings: false,
+                    unused: false,
+                    dead_code: false
                 },
                 output: {
                     comments: false


### PR DESCRIPTION
keep unused and dead_code in uglifyjs.
otherwise results in errors when using dynamic webpack chunks with `import`...